### PR TITLE
Workaround broken get_symbol_by_name

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HSARuntime"
 uuid = "2c364e2c-59fb-59c3-96f3-194112e690e0"
 authors = ["Julian P Samaroo <jpsamaroo@jpsamaroo.me"]
-version = "0.2.7"
+version = "0.2.8"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/deps/hsa_interface.jl
+++ b/deps/hsa_interface.jl
@@ -862,3 +862,18 @@ end
 function hsa_ext_sampler_destroy(agent, sampler)
     ccall((:hsa_ext_sampler_destroy, "libhsa-runtime64"), hsa_status_t, (hsa_agent_t, hsa_ext_sampler_t), agent, sampler)
 end
+
+# FIXME: Manually wrapped logging routines
+
+#=
+function hsa_ext_log_create(log::Ptr{hsa_log_t})
+    ccall((:hsa_ext_log_create, "libhsa-runtime64")
+
+function hsa_ext_log_load_program_code_object(executable, code_object_reader, options, loaded_code_object, log)
+    ccall((:hsa_ext_log_load_program_code_object, "libhsa-runtime64"), hsa_status_t, (hsa_executable_t, hsa_code_object_reader_t, Cstring, Ptr{hsa_loaded_code_object_t}, hsa_log_t), executable, code_object_reader, options, loaded_code_object, log)
+end
+
+function hsa_ext_log_load_agent_code_object(executable, agent, code_object_reader, options, loaded_code_object, log)
+    ccall((:hsa_ext_log_load_agent_code_object, "libhsa-runtime64"), hsa_status_t, (hsa_executable_t, hsa_agent_t, hsa_code_object_reader_t, Cstring, Ptr{hsa_loaded_code_object_t}, hsa_log_t), executable, agent, code_object_reader, options, loaded_code_object, log)
+end
+=#

--- a/deps/hsa_types.jl
+++ b/deps/hsa_types.jl
@@ -879,3 +879,7 @@ struct hsa_ext_images_1_pfn_s
 end
 
 const hsa_ext_images_1_pfn_t = hsa_ext_images_1_pfn_s
+
+struct hsa_log_t
+    handle::UInt64
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ if HSARuntime.configured
 
         agent_name = HSARuntime.get_name(agent)
         @test length(agent_name) > 0
+        @test !occursin('\0', agent_name)
 
         agent_isa = get_first_isa(agent)
         @test length(agent_isa) > 0


### PR DESCRIPTION
Workaround zero kernarg segment size
Strip trailing NULLs from get_name